### PR TITLE
#2: feat: use multiple threads to run different ETL pipelines

### DIFF
--- a/netflix_etl/etl.py
+++ b/netflix_etl/etl.py
@@ -1,4 +1,5 @@
 import logging
+from threading import Thread
 from time import sleep
 
 from netflix_etl.constants import ETL_REFRESH_TIME_SECONDS
@@ -8,9 +9,19 @@ from netflix_etl.pipelines import FilmworkPipeline, GenrePipeline
 def main():
     logging.debug("--- Start ETL pipelines")
 
-    pipelines_to_run = (FilmworkPipeline, GenrePipeline)
+    pipelines_to_run = (
+        FilmworkPipeline,
+        GenrePipeline,
+    )
+
+    threads = []
     for pipeline in pipelines_to_run:
-        pipeline().execute()
+        process = Thread(target=pipeline().execute)
+        process.start()
+        threads.append(process)
+
+    for process in threads:
+        process.join()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #2 

@Pycb asyncio меня победил, поэтому тут просто запускаем разные пайплайны в разных потоках